### PR TITLE
Support multiple dependencies with the same groupId:artifactId, but with the different classifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@ Provides lifecycles for
         <plugins>
           <plugin>
             <artifactId>maven-invoker-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.2</version>
             <configuration>
               <projectsDirectory>src/it</projectsDirectory>
               <cloneProjectsTo>target/it</cloneProjectsTo>

--- a/src/it/it0030-classifiers/pom.xml
+++ b/src/it/it0030-classifiers/pom.xml
@@ -1,0 +1,60 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.wix-maven.it</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../it-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0030</artifactId>
+  <packaging>msi</packaging>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>it0030 - test dependency with classifier</name>
+  <description>Integration test for a module that depends on artifact with multiple classifier</description>
+
+  <organization>
+    <name>Sample Org</name>
+  </organization>
+
+  <dependencies>
+    <!--  javafx-base depends on a platform specific artifact that has the same groupId and artifactId than itself  -->
+    <!--    <dependency>-->
+    <!--      <groupId>org.openjfx</groupId>-->
+    <!--      <artifactId>javafx-base</artifactId>-->
+    <!--      <version>16</version>-->
+    <!--      <classifier>${javafx.platform}</classifier>-->
+    <!--    </dependency>-->
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-base</artifactId>
+      <version>16</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.10</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <verbose>true</verbose>
+          <definitions>
+            <def>mavenVersion=${project.version}</def>
+            <def>mavenOrganisation=${project.organization.name}</def>
+            <def>testquote=string"with"quotes</def>
+          </definitions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/it0030-classifiers/src/main/wix/SampleFirst.wxs
+++ b/src/it/it0030-classifiers/src/main/wix/SampleFirst.wxs
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
+  <Product Name='JUnit 1.0' Id='00000001-86C7-4D14-AEC0-86416A69ABDE' UpgradeCode='00000001-7349-453F-94F6-BCB5110BA4FD'
+    Language='1033' Codepage='1252' Version='1.0.0' Manufacturer='Acme Ltd.'>
+
+    <Package Id='*' Keywords='Installer' Description="Acme's JUnit 1.0 Installer"
+      Comments='JUnit is a registered trademark of Acme Ltd.' Manufacturer='Acme Ltd.'
+      InstallerVersion='100' Languages='1033' Compressed='yes' SummaryCodepage='1252' />
+
+    <Media Id='1' Cabinet='Sample.cab' EmbedCab='yes' DiskPrompt="CD-ROM #1" />
+    <Property Id='DiskPrompt' Value="Acme's JUnit 1.0 Installation [1]" />
+
+    <Directory Id='TARGETDIR' Name='SourceDir'>
+      <Directory Id='ProgramFilesFolder' Name='PFiles'>
+        <Directory Id='Acme' Name='Acme'>
+          <Directory Id='INSTALLDIR' Name='JUnit 1.0'>
+
+            <Component Id='HelperLibrary' Guid='00000001-6BE3-460D-A14F-75658D16550B'>
+              <File Id='JUnit' Name='Junit.jar' DiskId='1' Source='$(var.junit.junit.TargetJAR)' KeyPath='yes' />
+            </Component>
+
+          </Directory>
+        </Directory>
+      </Directory>
+
+      <Directory Id="DesktopFolder" Name="Desktop" />
+    </Directory>
+
+    <Feature Id='Complete' Level='1'>
+      <ComponentRef Id='HelperLibrary' />
+    </Feature>
+
+  </Product>
+</Wix>

--- a/src/it/it0030-classifiers/verify.bsh
+++ b/src/it/it0030-classifiers/verify.bsh
@@ -1,0 +1,36 @@
+ /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import java.io.*;
+
+try
+{
+    File file = new File( basedir, "target/Release/x86/it0030-0.0.1-SNAPSHOT.msi" );
+    if ( !file.isFile() )
+    {
+        System.err.println( "Could not find installation package: " + file );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/main/java/com/github/wix_maven/AbstractCompilerMojo.java
+++ b/src/main/java/com/github/wix_maven/AbstractCompilerMojo.java
@@ -140,8 +140,14 @@ public abstract class AbstractCompilerMojo extends AbstractWixMojo {
         // so -b option used in linking cannot specify just the local repo, it must include the full
         // path to versioned package folder or 'target'
         // ie. foo/target/foo-1.jar repo/com/foo/1/foo-1.jar repo/net/foo/1/foo-1.jar
-        addDefinition(String.format("%1$s.%2$s.TargetJAR=%3$s", jar.getGroupId(),
-            jar.getArtifactId(), defineRepoFile(jar.getFile())));
+
+        if (jar.hasClassifier()) {
+          addDefinition(String.format("%1$s.%2$s.%3$s.TargetJAR=%4$s", jar.getGroupId(),
+              jar.getArtifactId(), jar.getClassifier(), defineRepoFile(jar.getFile())));
+        } else {
+          addDefinition(String.format("%1$s.%2$s.TargetJAR=%3$s", jar.getGroupId(),
+              jar.getArtifactId(), defineRepoFile(jar.getFile())));
+        }
       }
     }
   }


### PR DESCRIPTION
I needed to package a JavaFX application in a MSI using the wix-maven-plugin, but the it was failing with the following error because there was two jar files (javafx-base-16.jar and javafx-base-16-win.jar) with the same groupId:artifactId.

[INFO] candle.exe : error CNDL0288 : The variable 'org.openjfx.javafx-base.TargetJAR' with value 'org\openjfx\javafx-base\16\javafx-base-16-win.jar' was previously declared with value 'org\openjfx\javafx-base\16\javafx-base-16.jar'.

Adding the classifiers to the variable name fix this issue and the generated responseFile contains these lines : 

"-dorg.openjfx.javafx-base.win.TargetJAR=org\openjfx\javafx-base\16\javafx-base-16-win.jar"
"-dorg.openjfx.javafx-base.TargetJAR=org\openjfx\javafx-base\16\javafx-base-16.jar"