### PR TITLE
Reconfigure release pipeline for Sonatype Central Portal and GitHub Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,32 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'adopt'
+        cache: maven
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+      
+    # Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    - name: Update dependency graph
+      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/sonatype-publish.yml
+++ b/.github/workflows/sonatype-publish.yml
@@ -1,0 +1,71 @@
+name: Maven Library Publish
+
+on:
+  release:
+    types: [ created ]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17 for deploy to Sonatype
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: 17
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+
+      - name: Prepare Maven environnement with Java 17 for deployment to Sonatype
+        run: export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
+
+      - name: Publish to Apache Maven Central
+        run: mvn deploy -PsonatypeDeploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.NEXUS_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          # Path of the directory containing the static assets.
+          path: target\site # default is _site/
+
+  # Deployment mvn plugin site job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    
+    needs: publish
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+
+          

--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@ Provides lifecycles for
   <developers>
     <developer>
       <id>GdOmjan</id>
-      <email>Greg.Domjan@microfocus.com</email>
+      <email>GDomjan@opentext.com</email>
       <name>Greg Domjan</name>
-      <organization>NetIQ</organization>
+      <organization>OpenText</organization>
       <roles>
         <role>developer</role>
       </roles>
@@ -74,10 +74,12 @@ Provides lifecycles for
   </issueManagement>
 
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <github.global.server>github</github.global.server>
     <mavenVersion>2.2.1</mavenVersion>
     <wixtools.version>3.11.0</wixtools.version>
     <wixtools.groupId>org.wixtoolset.maven</wixtools.groupId>
+    <java.version>1.8</java.version>
   </properties>
   
   <dependencies>
@@ -158,8 +160,8 @@ Provides lifecycles for
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
         </configuration>
       </plugin>
 
@@ -274,19 +276,26 @@ Provides lifecycles for
       </build>
     </profile>
     <profile>
-      <id>sonatype-oss-release</id>
-      <activation>
-        <property>
-          <name>performRelease</name>
-          <value>true</value>
-        </property>
-      </activation>
+      <!-- required, used in .github/workflows/sonatype-publish.yml -->
+      <id>sonatypeDeploy</id>
       <build>
         <plugins>
           <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.10.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <tokenAuth>true</tokenAuth>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+            </configuration>
+          </plugin>
+          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -294,17 +303,24 @@ Provides lifecycles for
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
               </execution>
             </executions>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
+            <version>3.3.0</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
                 <goals>
-                  <goal>jar</goal>
+                  <goal>jar-no-fork</goal>
                 </goals>
               </execution>
             </executions>
@@ -312,6 +328,7 @@ Provides lifecycles for
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.6.3</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>


### PR DESCRIPTION
This PR switches publishing to Sonatype Central Portal and adds GitHub Actions automation for CI, release publishing, and GitHub Pages deployment.

It introduces:

A CI workflow on pushes/PRs to master
A release workflow that deploys artifacts to Maven Central using token auth and GPG signing
Maven profile and plugin updates in the project POM to support Central Portal publishing

Why
Sonatype OSSRH-style release flows have moved to Central Portal workflows. This PR aligns the project with Central token-based publishing and ensures releases can be executed from GitHub in a repeatable, auditable way.